### PR TITLE
Bug fix for IBM discourse url not linking to discourse post.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Fully remote team, headquartered in Chicago.
 ### Planning
 
 * [IBM]'s [Decision Composer] app makes heavy use of Elm.
-  [Discourse announcement](IBM-Discourse).
+  [Discourse announcement](https://discourse.elm-lang.org/t/ibm-releases-elm-powered-app/2364).
 * [KOVnet](http://www.kovnet.nl)
   ([GitHub](https://github.com/kdvnet)) - Planning for daycare centers.
   Planning children and careworkers, invoicing parents.
@@ -204,7 +204,6 @@ Fully remote team, headquartered in Chicago.
 
 [IBM]: https://www.ibm.com/au-en/
 [Decision Composer]: https://decision-composer.ibm.com/
-[IBM-Discourse]: https://discourse.elm-lang.org/t/ibm-releases-elm-powered-app/2364
 
 
 #### Project Management


### PR DESCRIPTION
Hey, this isn't an addition of a company, but just a simple URL fix. The current discourse 
URL takes you to here:
![image](https://user-images.githubusercontent.com/19433583/61712733-fb6a8200-ad24-11e9-9698-cab57a3c19fe.png)

But it should take you to here
![image](https://user-images.githubusercontent.com/19433583/61712758-0b826180-ad25-11e9-9bca-2cb206099234.png)

This PR addresses this issue.