### PR TITLE
Add brilliant.org to Education list closes #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ Inspired by Doomspork's [Elixir companies][elixir-companies] list.
 
 #### Education
 
+* [Brilliant](https://brilliant.org/) 
+  ([GitHub](https://github.com/orgs/brilliantorg/repositories?language=elm))
+  Brilliant is an online learning platform that replaces lecture videos 
+  with hands-on, interactive lessons.
+  Based in San Francisco with remote team members.
+  ([Hiring](https://brilliant.org/careers/))
 * [DailyDrip](https://www.dailydrip.com/)
   ([GitHub](https://github.com/dailydrip)) -
   DailyDrip is a continuous education platform.  Daily bite-sized videos on new tech.


### PR DESCRIPTION
As discussed in #51 adding https://brilliant.org/ to the list. 

Re-reviewed [Contribution Guidelines](https://github.com/lpil/elm-companies/blob/master/CONTRIBUTING.md) to ensure  changes abides.

Checklist:

- [x] Company name: brilliant.org
- [x] Company description - borrowed from their website
- [x] Company location - SF + Remote
- [x] GitHub link 
- [x] Sorted alphabetically
- [x] Lines wrapped at 80 chars

Thanks.